### PR TITLE
Add Neon Runner 3D web endless-runner (Three.js)

### DIFF
--- a/game.js
+++ b/game.js
@@ -1,0 +1,272 @@
+import * as THREE from "https://unpkg.com/three@0.160.0/build/three.module.js";
+
+const canvas = document.querySelector("#game");
+const overlay = document.querySelector("#overlay");
+const startButton = document.querySelector("#start");
+const scoreEl = document.querySelector("#score");
+
+const scene = new THREE.Scene();
+scene.fog = new THREE.Fog(0x05070f, 12, 42);
+
+const camera = new THREE.PerspectiveCamera(
+  65,
+  window.innerWidth / window.innerHeight,
+  0.1,
+  100
+);
+camera.position.set(0, 5, 12);
+
+const renderer = new THREE.WebGLRenderer({ canvas, antialias: true });
+renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
+renderer.setSize(window.innerWidth, window.innerHeight);
+renderer.setClearColor(0x05070f, 1);
+
+const hemiLight = new THREE.HemisphereLight(0x9ad8ff, 0x2b124a, 1.1);
+scene.add(hemiLight);
+
+const spotLight = new THREE.SpotLight(0x4ff3ff, 2.5, 50, Math.PI / 6, 0.3, 1);
+spotLight.position.set(0, 18, 10);
+spotLight.castShadow = true;
+scene.add(spotLight);
+
+const lanePositions = [-3, 0, 3];
+const trackSegments = [];
+const obstacles = [];
+let speed = 0.35;
+let score = 0;
+let isRunning = false;
+let jumpVelocity = 0;
+let isJumping = false;
+let targetLane = 1;
+
+const runnerGroup = new THREE.Group();
+const runnerMaterial = new THREE.MeshStandardMaterial({
+  color: 0x7f5dff,
+  emissive: 0x3b1fff,
+  emissiveIntensity: 0.6,
+  roughness: 0.4,
+  metalness: 0.3,
+});
+
+const runnerBody = new THREE.Mesh(
+  new THREE.BoxGeometry(1.2, 1.8, 0.8),
+  runnerMaterial
+);
+runnerBody.position.y = 1.2;
+const runnerHead = new THREE.Mesh(
+  new THREE.BoxGeometry(0.9, 0.9, 0.9),
+  new THREE.MeshStandardMaterial({
+    color: 0x74fff0,
+    emissive: 0x2ff7d9,
+    emissiveIntensity: 0.9,
+  })
+);
+runnerHead.position.y = 2.3;
+
+runnerGroup.add(runnerBody, runnerHead);
+scene.add(runnerGroup);
+
+const groundMaterial = new THREE.MeshStandardMaterial({
+  color: 0x0c1a34,
+  roughness: 0.6,
+  metalness: 0.1,
+});
+
+const laneLightMaterial = new THREE.MeshStandardMaterial({
+  color: 0x2ddcff,
+  emissive: 0x1fa8ff,
+  emissiveIntensity: 0.9,
+  roughness: 0.3,
+  metalness: 0.4,
+});
+
+function createTrackSegment(z) {
+  const segment = new THREE.Group();
+
+  const base = new THREE.Mesh(new THREE.BoxGeometry(12, 0.4, 12), groundMaterial);
+  base.position.y = -0.2;
+  base.position.z = z;
+
+  const laneLeft = new THREE.Mesh(new THREE.BoxGeometry(0.15, 0.15, 12), laneLightMaterial);
+  laneLeft.position.set(-3, 0.05, z);
+  const laneRight = new THREE.Mesh(new THREE.BoxGeometry(0.15, 0.15, 12), laneLightMaterial);
+  laneRight.position.set(3, 0.05, z);
+
+  segment.add(base, laneLeft, laneRight);
+  scene.add(segment);
+  trackSegments.push(segment);
+}
+
+for (let i = 0; i < 8; i += 1) {
+  createTrackSegment(-i * 12);
+}
+
+const obstacleMaterial = new THREE.MeshStandardMaterial({
+  color: 0xff507a,
+  emissive: 0xff2e63,
+  emissiveIntensity: 0.6,
+});
+
+function spawnObstacle(z) {
+  const obstacle = new THREE.Mesh(new THREE.BoxGeometry(1.4, 1.4, 1.4), obstacleMaterial);
+  const laneIndex = Math.floor(Math.random() * lanePositions.length);
+  obstacle.position.set(lanePositions[laneIndex], 0.7, z);
+  obstacle.userData = { laneIndex };
+  scene.add(obstacle);
+  obstacles.push(obstacle);
+}
+
+function resetGame() {
+  obstacles.forEach((obstacle) => scene.remove(obstacle));
+  obstacles.length = 0;
+  trackSegments.forEach((segment) => scene.remove(segment));
+  trackSegments.length = 0;
+  for (let i = 0; i < 8; i += 1) {
+    createTrackSegment(-i * 12);
+  }
+  runnerGroup.position.set(0, 0, 0);
+  targetLane = 1;
+  jumpVelocity = 0;
+  isJumping = false;
+  score = 0;
+  speed = 0.35;
+  scoreEl.textContent = "0";
+  for (let i = 1; i <= 6; i += 1) {
+    spawnObstacle(-20 - i * 10);
+  }
+}
+
+function handleLaneChange(direction) {
+  if (!isRunning) return;
+  const nextLane = THREE.MathUtils.clamp(targetLane + direction, 0, lanePositions.length - 1);
+  targetLane = nextLane;
+}
+
+function handleJump() {
+  if (!isRunning || isJumping) return;
+  isJumping = true;
+  jumpVelocity = 0.35;
+}
+
+window.addEventListener("keydown", (event) => {
+  if (event.key === "ArrowLeft") {
+    handleLaneChange(-1);
+  }
+  if (event.key === "ArrowRight") {
+    handleLaneChange(1);
+  }
+  if (event.key === " " || event.key === "ArrowUp") {
+    handleJump();
+  }
+});
+
+let touchStartX = 0;
+let touchStartY = 0;
+
+window.addEventListener("touchstart", (event) => {
+  const touch = event.touches[0];
+  touchStartX = touch.clientX;
+  touchStartY = touch.clientY;
+});
+
+window.addEventListener("touchend", (event) => {
+  const touch = event.changedTouches[0];
+  const deltaX = touch.clientX - touchStartX;
+  const deltaY = touch.clientY - touchStartY;
+  if (Math.abs(deltaX) > Math.abs(deltaY) && Math.abs(deltaX) > 30) {
+    handleLaneChange(deltaX > 0 ? 1 : -1);
+  } else if (deltaY < -30) {
+    handleJump();
+  }
+});
+
+startButton.addEventListener("click", () => {
+  resetGame();
+  overlay.classList.add("hidden");
+  isRunning = true;
+});
+
+function updateRunner() {
+  const targetX = lanePositions[targetLane];
+  runnerGroup.position.x += (targetX - runnerGroup.position.x) * 0.2;
+
+  if (isJumping) {
+    runnerGroup.position.y += jumpVelocity;
+    jumpVelocity -= 0.02;
+    if (runnerGroup.position.y <= 0) {
+      runnerGroup.position.y = 0;
+      isJumping = false;
+      jumpVelocity = 0;
+    }
+  }
+}
+
+function updateTrack() {
+  trackSegments.forEach((segment) => {
+    segment.children.forEach((mesh) => {
+      mesh.position.z += speed;
+    });
+  });
+
+  const firstSegment = trackSegments[0];
+  if (firstSegment.children[0].position.z > 6) {
+    trackSegments.shift();
+    firstSegment.children.forEach((mesh) => scene.remove(mesh));
+    const lastSegment = trackSegments[trackSegments.length - 1];
+    createTrackSegment(lastSegment.children[0].position.z - 12);
+  }
+}
+
+function updateObstacles() {
+  obstacles.forEach((obstacle) => {
+    obstacle.position.z += speed;
+  });
+
+  if (obstacles[0] && obstacles[0].position.z > 8) {
+    const old = obstacles.shift();
+    scene.remove(old);
+    const farthest = obstacles[obstacles.length - 1];
+    spawnObstacle(farthest.position.z - 10 - Math.random() * 6);
+  }
+}
+
+function checkCollisions() {
+  const runnerBox = new THREE.Box3().setFromObject(runnerGroup);
+  for (const obstacle of obstacles) {
+    const obstacleBox = new THREE.Box3().setFromObject(obstacle);
+    if (runnerBox.intersectsBox(obstacleBox)) {
+      isRunning = false;
+      overlay.classList.remove("hidden");
+      startButton.textContent = "Run Again";
+      return;
+    }
+  }
+}
+
+function updateScore() {
+  score += speed * 2.2;
+  scoreEl.textContent = Math.floor(score).toString();
+  if (score > 200 && speed < 0.55) {
+    speed += 0.0005;
+  }
+}
+
+function animate() {
+  requestAnimationFrame(animate);
+  if (isRunning) {
+    updateRunner();
+    updateTrack();
+    updateObstacles();
+    checkCollisions();
+    updateScore();
+  }
+  renderer.render(scene, camera);
+}
+
+animate();
+
+window.addEventListener("resize", () => {
+  camera.aspect = window.innerWidth / window.innerHeight;
+  camera.updateProjectionMatrix();
+  renderer.setSize(window.innerWidth, window.innerHeight);
+});

--- a/index.html
+++ b/index.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Neon Runner 3D</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <div class="hud">
+      <div>
+        <h1>Neon Runner 3D</h1>
+        <p>Swipe or use ◀ ▶ to change lanes. Jump with ␣.</p>
+      </div>
+      <div class="stats">
+        <span id="score">0</span> m
+      </div>
+    </div>
+    <div id="overlay" class="overlay">
+      <div class="overlay-card">
+        <h2>Subway Surfers-inspired Run</h2>
+        <p>Dodge barriers, stay in the neon lanes, and rack up distance.</p>
+        <button id="start">Start Run</button>
+      </div>
+    </div>
+    <canvas id="game"></canvas>
+    <script type="module" src="game.js"></script>
+  </body>
+</html>

--- a/style.css
+++ b/style.css
@@ -1,0 +1,119 @@
+:root {
+  color-scheme: dark;
+  font-family: "Inter", "Segoe UI", system-ui, sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  background: radial-gradient(circle at top, #0e1a2b, #05070f 70%);
+  color: #f8f9ff;
+  height: 100vh;
+  overflow: hidden;
+}
+
+canvas {
+  display: block;
+  height: 100vh;
+  width: 100vw;
+}
+
+.hud {
+  align-items: center;
+  display: flex;
+  justify-content: space-between;
+  left: 0;
+  padding: 1.5rem 2rem;
+  pointer-events: none;
+  position: fixed;
+  top: 0;
+  width: 100%;
+  z-index: 2;
+}
+
+.hud h1 {
+  font-size: 1.5rem;
+  letter-spacing: 0.1rem;
+  text-transform: uppercase;
+}
+
+.hud p {
+  color: rgba(248, 249, 255, 0.7);
+  font-size: 0.9rem;
+  margin-top: 0.5rem;
+}
+
+.stats {
+  backdrop-filter: blur(12px);
+  background: rgba(8, 16, 29, 0.7);
+  border: 1px solid rgba(117, 204, 255, 0.2);
+  border-radius: 999px;
+  font-size: 1.1rem;
+  padding: 0.6rem 1.2rem;
+}
+
+.overlay {
+  align-items: center;
+  background: rgba(1, 4, 10, 0.7);
+  display: flex;
+  height: 100vh;
+  inset: 0;
+  justify-content: center;
+  position: fixed;
+  width: 100vw;
+  z-index: 3;
+}
+
+.overlay.hidden {
+  display: none;
+}
+
+.overlay-card {
+  backdrop-filter: blur(18px);
+  background: rgba(6, 10, 22, 0.9);
+  border: 1px solid rgba(93, 203, 255, 0.3);
+  border-radius: 24px;
+  box-shadow: 0 25px 60px rgba(0, 0, 0, 0.45);
+  max-width: 420px;
+  padding: 2.5rem;
+  text-align: center;
+}
+
+.overlay-card h2 {
+  font-size: 1.6rem;
+  margin-bottom: 1rem;
+}
+
+.overlay-card p {
+  color: rgba(248, 249, 255, 0.8);
+  margin-bottom: 1.8rem;
+}
+
+.overlay-card button {
+  background: linear-gradient(130deg, #3fe2ff, #6e4bff);
+  border: none;
+  border-radius: 999px;
+  color: #05070f;
+  cursor: pointer;
+  font-size: 1rem;
+  font-weight: 600;
+  padding: 0.8rem 2.2rem;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.overlay-card button:hover {
+  box-shadow: 0 0 24px rgba(63, 226, 255, 0.45);
+  transform: translateY(-2px);
+}
+
+@media (max-width: 600px) {
+  .hud {
+    flex-direction: column;
+    gap: 0.75rem;
+    text-align: center;
+  }
+}


### PR DESCRIPTION
### Motivation
- Provide a small, playable Subway Surfers-style endless runner demo that runs in the browser using Three.js. 
- Offer a full-screen canvas experience with a simple HUD and start overlay for quick play and iteration. 
- Improve track recycling logic to avoid segment misplacement when advancing the track.

### Description
- Add `index.html` which mounts a full-screen `<canvas>` and a start overlay/HUD with `#start` and `#score` elements. 
- Add `style.css` with dark/neon styling, HUD layout, and an overlay card for the start dialog. 
- Add `game.js` implementing the Three.js scene: runner mesh, procedural track segments, obstacle spawning, lane switching, jump physics, scoring, and collision detection. 
- Fix track recycling in `updateTrack()` to remove the first (passed) segment and append a new segment after the last one to maintain continuous track flow.

### Testing
- Served the site with `python -m http.server 8000` and verified `HTTP/1.0 200 OK` responses from `curl` to `index.html`. (success) 
- Automated browser checks were run with Playwright to load the page and capture a screenshot artifact; an initial Playwright attempt timed out but a subsequent run produced a screenshot artifact successfully. (final screenshot creation succeeded) 
- Manual visual verification was performed by loading the page and confirming the start overlay, HUD, and that the canvas bootstrapped the Three.js scene. (observational)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6983241728cc832f845f48b84bd400d5)